### PR TITLE
Modified phosphobot pyproject for FT

### DIFF
--- a/phosphobot/pyproject.toml
+++ b/phosphobot/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "typer>=0.15.1",
     "websockets>=14.1",
     "huggingface-hub>=0.28.0",
-    "datasets>=3.2.0",
+    "datasets<=3.6.0",
     "sentry-sdk[fastapi]>=2.20.0",
     "posthog>=6.0.0",
     "piper-sdk>=0.1.16",
@@ -49,7 +49,7 @@ dependencies = [
     "wasmtime>=33.0.0",
     "async-property>=0.2.2",
     "torch>=2.7.0",
-    "lerobot"
+    "lerobot",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
datasetsのバージョン不適合が発生するようになったため、手続き化のためpyproject.tomlを修正